### PR TITLE
fix(go-services): mysql healthcheck false-healthy race (kafka-ecommerce CI flake)

### DIFF
--- a/go-services/docker-compose.yml
+++ b/go-services/docker-compose.yml
@@ -14,10 +14,19 @@ services:
     volumes:
       - ./user_service/db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      # TCP+creds probe: only the fully-started real server on :3306 answers.
+      # The old `ping -h localhost` hit MySQL 8.0's socket-only TEMPORARY init
+      # server and passed on exit-code-only (even "Access denied"), so the
+      # container was marked healthy ~3s before the real :3306 listener was up.
+      # A dependent service connecting over TCP then started too early and
+      # failed during the temp-server -> real-server restart gap (intermittent
+      # "container unhealthy" / "dependency failed to start" in CI).
+      test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "3306", "-uroot", "-proot" ]
       interval: 5s
       timeout: 5s
       retries: 20
+      # Cold init (slow under CI contention) shouldn't burn the retry budget.
+      start_period: 60s
 
   mysql-products:
     image: mysql:8.0
@@ -34,10 +43,19 @@ services:
     volumes:
       - ./product_service/db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      # TCP+creds probe: only the fully-started real server on :3306 answers.
+      # The old `ping -h localhost` hit MySQL 8.0's socket-only TEMPORARY init
+      # server and passed on exit-code-only (even "Access denied"), so the
+      # container was marked healthy ~3s before the real :3306 listener was up.
+      # A dependent service connecting over TCP then started too early and
+      # failed during the temp-server -> real-server restart gap (intermittent
+      # "container unhealthy" / "dependency failed to start" in CI).
+      test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "3306", "-uroot", "-proot" ]
       interval: 5s
       timeout: 5s
       retries: 20
+      # Cold init (slow under CI contention) shouldn't burn the retry budget.
+      start_period: 60s
 
   mysql-orders:
     image: mysql:8.0
@@ -54,10 +72,19 @@ services:
     volumes:
       - ./order_service/db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      # TCP+creds probe: only the fully-started real server on :3306 answers.
+      # The old `ping -h localhost` hit MySQL 8.0's socket-only TEMPORARY init
+      # server and passed on exit-code-only (even "Access denied"), so the
+      # container was marked healthy ~3s before the real :3306 listener was up.
+      # A dependent service connecting over TCP then started too early and
+      # failed during the temp-server -> real-server restart gap (intermittent
+      # "container unhealthy" / "dependency failed to start" in CI).
+      test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "3306", "-uroot", "-proot" ]
       interval: 5s
       timeout: 5s
       retries: 20
+      # Cold init (slow under CI contention) shouldn't burn the retry budget.
+      start_period: 60s
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0


### PR DESCRIPTION
## What
Fix the intermittent **`mysql-users/products/orders` "container unhealthy" → "dependency failed to start"** flake (seen in keploy/enterprise's `kafka-ecommerce` CI lane, which clones this repo's `go` branch and runs `go-services` under `keploy record`).

## Root cause (traced)
The mysql healthchecks used `mysqladmin ping -h localhost`. MySQL 8.0's entrypoint first runs a **temporary, socket-only init server** (to apply the seed `db.sql`), then stops it and starts the real server on `:3306`. `ping -h localhost` hits that **unix socket** and checks **exit code only** — and `mysqladmin` exits `0` even on "Access denied". A per-second trace caught the probe reporting `mysqld is alive` at **t=8s against the temp server**, ~3s before the real `:3306` listener came up (t=11s).

So docker marked the container **healthy on the temp server**. A dependent service (`condition: service_healthy`) that connects over **TCP `mysql-users:3306`** then started too early and failed during the temp→real restart gap (~4-6s, wider under load); docker's next probes hit the now-stopped temp server, driving the failing streak to the 20-retry limit → `unhealthy`. There was also **no `start_period`**, so cold-init failures under CI contention burned the retry budget.

## Fix
Probe the **real TCP listener with root creds** — `mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -proot` (only the fully-started real server answers on `:3306`, never the temp server) — and add **`start_period: 60s`** so slow cold init doesn't count against the retries. Applied to all three mysql services.

## Validation
- `docker compose config` validates.
- Per-second health trace **before**: healthy at t=8s with `Access denied … (using password: NO)` — i.e. healthy without a real connection, against the temp server.
- **After**: `FailingStreak` stays 0 through cold init (absorbed by `start_period`); healthy only at t=16s with `mysqld is alive` over real TCP `:3306` — never the temp server. 5/5 cold-start loops healthy.

Only the three mysql healthchecks change (+30/−3); no service/app changes.
