### PR TITLE
fix(go-services): TCP-based MySQL healthcheck so dependents wait for real readiness

### DIFF
--- a/go-services/docker-compose.yml
+++ b/go-services/docker-compose.yml
@@ -14,10 +14,16 @@ services:
     volumes:
       - ./user_service/db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      # -h 127.0.0.1 forces a TCP check: during MySQL's init phase the server
+      # listens only on the unix socket (skip-networking), so `-h localhost`
+      # (socket) reports healthy before the network port is serving — dependents
+      # gated on service_healthy then start early and hit "connection refused".
+      # A TCP probe only passes once 3306 is actually accepting connections.
+      test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--protocol=tcp" ]
       interval: 5s
       timeout: 5s
       retries: 20
+      start_period: 60s
 
   mysql-products:
     image: mysql:8.0
@@ -34,10 +40,16 @@ services:
     volumes:
       - ./product_service/db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      # -h 127.0.0.1 forces a TCP check: during MySQL's init phase the server
+      # listens only on the unix socket (skip-networking), so `-h localhost`
+      # (socket) reports healthy before the network port is serving — dependents
+      # gated on service_healthy then start early and hit "connection refused".
+      # A TCP probe only passes once 3306 is actually accepting connections.
+      test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--protocol=tcp" ]
       interval: 5s
       timeout: 5s
       retries: 20
+      start_period: 60s
 
   mysql-orders:
     image: mysql:8.0
@@ -54,10 +66,16 @@ services:
     volumes:
       - ./order_service/db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      # -h 127.0.0.1 forces a TCP check: during MySQL's init phase the server
+      # listens only on the unix socket (skip-networking), so `-h localhost`
+      # (socket) reports healthy before the network port is serving — dependents
+      # gated on service_healthy then start early and hit "connection refused".
+      # A TCP probe only passes once 3306 is actually accepting connections.
+      test: [ "CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "--protocol=tcp" ]
       interval: 5s
       timeout: 5s
       retries: 20
+      start_period: 60s
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0


### PR DESCRIPTION
## Problem

The kafka-ecommerce CI lane fails intermittently with:
```
user_service | panic: failed to connect to database after 30 retries: dial tcp …:3306: connect: connection refused
ERROR error while running the app {"error": "exit status 143"}
ERROR: user_service failed to start
```

The compose **already** gates app services on `depends_on: { mysql-*: condition: service_healthy }` — but the healthcheck was `mysqladmin ping -h localhost`, which probes the **unix socket**. During MySQL's init phase the server runs on the socket only (`--skip-networking`) while it applies `/docker-entrypoint-initdb.d/*.sql`, so the socket ping reports **healthy before the TCP port (3306) is serving**. The dependents then start early and their TCP connect to `mysql-*:3306` is refused; under CI load (slow init) they exhaust the 30-retry budget and panic. Hence the intermittency.

## Fix

Force a **TCP** probe — `mysqladmin ping -h 127.0.0.1 --protocol=tcp` — for all three MySQL services, so `service_healthy` only fires once 3306 actually accepts connections. Added `start_period: 60s` so a slow init under contention isn't counted as failing. Dependents now reliably wait for a connectable database.

Root-cause fix (correct readiness signal), not a retry/sleep workaround. `docker compose config` validates; the only change is the three healthcheck blocks.